### PR TITLE
Add URL-based view sharing to basic demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.playwright-cli/

--- a/examples/basic/main.ts
+++ b/examples/basic/main.ts
@@ -2,6 +2,7 @@ import maplibregl from 'maplibre-gl';
 import { UsgsLidarControl, UsgsLidarLayerAdapter } from '../../src/index';
 import { LayerControl } from 'maplibre-gl-layer-control';
 import { Legend, TerrainControl } from 'maplibre-gl-components';
+import { addShareButton, applyHashState, parseHash } from './urlState';
 
 import '../../src/index.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -115,6 +116,40 @@ map.on('load', () => {
 
   // Add USGS LiDAR control to the map (after layer control)
   map.addControl(usgsLidarControl, 'top-right');
+
+  // Track the most recently loaded dataset id for the share URL
+  let lastLoadedId: string | null = null;
+  usgsLidarControl.on('loadcomplete', (event) => {
+    const loaded = event.state.loadedItems;
+    if (loaded.size === 0) return;
+    // Use the last entry as the most recent load
+    const ids = Array.from(loaded.keys());
+    lastLoadedId = ids[ids.length - 1];
+  });
+  usgsLidarControl.on('unload', (event) => {
+    if (event.state.loadedItems.size === 0) {
+      lastLoadedId = null;
+    } else if (lastLoadedId && !event.state.loadedItems.has(lastLoadedId)) {
+      const ids = Array.from(event.state.loadedItems.keys());
+      lastLoadedId = ids[ids.length - 1];
+    }
+  });
+
+  // Inject the share button into the panel (idempotent)
+  const ensureShareButton = () => addShareButton(usgsLidarControl, map, () => lastLoadedId);
+  ensureShareButton();
+  usgsLidarControl.on('expand', ensureShareButton);
+
+  // Restore state from URL hash, if any
+  const hashState = parseHash(window.location.hash);
+  if (Object.keys(hashState).length > 0) {
+    applyHashState(map, usgsLidarControl, hashState).catch((err) => {
+      console.warn('[share-url] Failed to apply hash state:', err);
+    });
+    if (hashState.id) {
+      usgsLidarControl.expand();
+    }
+  }
 
   // Add a legend with zoom visibility control
   const lidarLegend = new Legend({

--- a/examples/basic/urlState.ts
+++ b/examples/basic/urlState.ts
@@ -1,0 +1,307 @@
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import type { UsgsLidarControl, DataSourceType, UnifiedSearchItem } from '../../src/index';
+
+export interface HashState {
+  lon?: number;
+  lat?: number;
+  zoom?: number;
+  pitch?: number;
+  bearing?: number;
+  source?: DataSourceType;
+  id?: string;
+  ptSize?: number;
+  opacity?: number;
+  color?: string;
+  cmap?: string;
+  zoff?: number;
+}
+
+const round = (n: number, dp: number): number => {
+  const f = Math.pow(10, dp);
+  return Math.round(n * f) / f;
+};
+
+const isFiniteNumber = (n: unknown): n is number =>
+  typeof n === 'number' && Number.isFinite(n);
+
+export function parseHash(hash: string): HashState {
+  const state: HashState = {};
+  const trimmed = hash.startsWith('#') ? hash.slice(1) : hash;
+  if (!trimmed) return state;
+
+  for (const part of trimmed.split('&')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const key = decodeURIComponent(part.slice(0, eq));
+    const value = decodeURIComponent(part.slice(eq + 1));
+    if (!value) continue;
+
+    switch (key) {
+      case 'lon': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.lon = n;
+        break;
+      }
+      case 'lat': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.lat = n;
+        break;
+      }
+      case 'zoom': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.zoom = n;
+        break;
+      }
+      case 'pitch': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.pitch = n;
+        break;
+      }
+      case 'bearing': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.bearing = n;
+        break;
+      }
+      case 'source':
+        if (value === 'copc' || value === 'ept') state.source = value;
+        break;
+      case 'id':
+        state.id = value;
+        break;
+      case 'ptSize': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.ptSize = n;
+        break;
+      }
+      case 'opacity': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.opacity = n;
+        break;
+      }
+      case 'color':
+        state.color = value;
+        break;
+      case 'cmap':
+        state.cmap = value;
+        break;
+      case 'zoff': {
+        const n = parseFloat(value);
+        if (isFiniteNumber(n)) state.zoff = n;
+        break;
+      }
+    }
+  }
+  return state;
+}
+
+export function buildHash(
+  map: MapLibreMap,
+  control: UsgsLidarControl,
+  lastLoadedId: string | null
+): string {
+  const center = map.getCenter();
+  const parts: string[] = [
+    `lon=${round(center.lng, 6)}`,
+    `lat=${round(center.lat, 6)}`,
+    `zoom=${round(map.getZoom(), 2)}`,
+    `pitch=${round(map.getPitch(), 1)}`,
+    `bearing=${round(map.getBearing(), 1)}`,
+    `source=${control.getDataSource()}`,
+  ];
+
+  if (lastLoadedId) {
+    parts.push(`id=${encodeURIComponent(lastLoadedId)}`);
+  }
+
+  const lidarState = control.getState().lidarState as
+    | {
+        pointSize?: number;
+        opacity?: number;
+        colorScheme?: unknown;
+        colormap?: string;
+        zOffset?: number;
+      }
+    | null;
+
+  if (lidarState) {
+    if (isFiniteNumber(lidarState.pointSize)) {
+      parts.push(`ptSize=${round(lidarState.pointSize, 1)}`);
+    }
+    if (isFiniteNumber(lidarState.opacity)) {
+      parts.push(`opacity=${round(lidarState.opacity, 2)}`);
+    }
+    if (typeof lidarState.colorScheme === 'string') {
+      parts.push(`color=${encodeURIComponent(lidarState.colorScheme)}`);
+    }
+    if (typeof lidarState.colormap === 'string') {
+      parts.push(`cmap=${encodeURIComponent(lidarState.colormap)}`);
+    }
+    if (isFiniteNumber(lidarState.zOffset)) {
+      parts.push(`zoff=${round(lidarState.zOffset, 1)}`);
+    }
+  }
+
+  return '#' + parts.join('&');
+}
+
+export function buildShareUrl(
+  map: MapLibreMap,
+  control: UsgsLidarControl,
+  lastLoadedId: string | null
+): string {
+  return window.location.origin + window.location.pathname + buildHash(map, control, lastLoadedId);
+}
+
+/**
+ * Applies a parsed hash state on page load: jumps the camera, sets the data
+ * source, runs a search, auto-loads the item matching `id`, and applies viz
+ * params. Logs warnings on missing or invalid pieces; never throws.
+ */
+export async function applyHashState(
+  map: MapLibreMap,
+  control: UsgsLidarControl,
+  state: HashState
+): Promise<void> {
+  // Camera
+  const hasLon = isFiniteNumber(state.lon);
+  const hasLat = isFiniteNumber(state.lat);
+  if (hasLon && hasLat) {
+    map.jumpTo({
+      center: [state.lon as number, state.lat as number],
+      zoom: isFiniteNumber(state.zoom) ? state.zoom : map.getZoom(),
+      pitch: isFiniteNumber(state.pitch) ? state.pitch : map.getPitch(),
+      bearing: isFiniteNumber(state.bearing) ? state.bearing : map.getBearing(),
+    });
+  }
+
+  // Data source
+  if (state.source) {
+    control.setDataSource(state.source);
+  }
+
+  // Auto-load by id
+  if (state.id) {
+    await new Promise<void>((resolve) => {
+      const ready = () => map.once('idle', () => resolve());
+      if (map.loaded()) ready();
+      else map.once('load', ready);
+    });
+
+    try {
+      const results: UnifiedSearchItem[] = await control.searchByExtent();
+      const match = results.find((item) => item.id === state.id);
+      if (!match) {
+        console.warn(
+          `[share-url] No dataset with id="${state.id}" in the current search results.`
+        );
+      } else {
+        await control.loadItem(match);
+      }
+    } catch (err) {
+      console.warn('[share-url] Search/load failed while restoring state:', err);
+    }
+  }
+
+  // Viz params (apply after load so the underlying lidar control has a point cloud)
+  if (isFiniteNumber(state.ptSize)) control.setPointSize(state.ptSize);
+  if (isFiniteNumber(state.opacity)) control.setOpacity(state.opacity);
+  if (state.color) {
+    // ColorScheme is typed broadly upstream; cast at the boundary.
+    control.setColorScheme(state.color as Parameters<UsgsLidarControl['setColorScheme']>[0]);
+  }
+  if (state.cmap) {
+    control.setColormap(state.cmap as Parameters<UsgsLidarControl['setColormap']>[0]);
+  }
+  if (isFiniteNumber(state.zoff)) control.setZOffset(state.zoff);
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(ta);
+  }
+}
+
+/**
+ * Adds a "Share URL" button to the bottom of the control's panel.
+ *
+ * Clicking the button builds a share URL from the current map and control
+ * state and copies it to the clipboard. A short confirmation message is
+ * shown next to the button.
+ */
+export function addShareButton(
+  control: UsgsLidarControl,
+  map: MapLibreMap,
+  getLastLoadedId: () => string | null
+): void {
+  const panel = control.getPanelElement();
+  if (!panel) {
+    console.warn('[share-url] Panel element not available; share button skipped.');
+    return;
+  }
+
+  // Avoid duplicate injection
+  if (panel.querySelector('.usgs-lidar-share-row')) return;
+
+  const row = document.createElement('div');
+  row.className = 'usgs-lidar-section usgs-lidar-share-row';
+  row.style.padding = '8px 12px';
+  row.style.display = 'flex';
+  row.style.alignItems = 'center';
+  row.style.gap = '8px';
+
+  const btn = document.createElement('button');
+  btn.className = 'usgs-lidar-btn usgs-lidar-btn-primary';
+  btn.type = 'button';
+  btn.id = 'usgs-lidar-share-btn';
+  btn.textContent = 'Share URL';
+  btn.title = 'Copy a shareable URL with the current map view and dataset';
+
+  const status = document.createElement('span');
+  status.className = 'usgs-lidar-share-status';
+  status.style.fontSize = '12px';
+  status.style.color = '#16a34a';
+  status.style.opacity = '0';
+  status.style.transition = 'opacity 0.2s ease';
+  status.setAttribute('aria-live', 'polite');
+
+  let resetTimer: number | null = null;
+  const showStatus = (text: string, isError = false) => {
+    status.textContent = text;
+    status.style.color = isError ? '#dc2626' : '#16a34a';
+    status.style.opacity = '1';
+    if (resetTimer !== null) window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      status.style.opacity = '0';
+    }, 2500);
+  };
+
+  btn.addEventListener('click', async () => {
+    const url = buildShareUrl(map, control, getLastLoadedId());
+    // Reflect in the address bar so the user can also copy from there if they want.
+    history.replaceState(null, '', url);
+    try {
+      await copyToClipboard(url);
+      showStatus('Copied!');
+    } catch (err) {
+      console.error('[share-url] Clipboard copy failed:', err);
+      showStatus('Copy failed', true);
+    }
+  });
+
+  row.appendChild(btn);
+  row.appendChild(status);
+  panel.appendChild(row);
+}

--- a/examples/basic/urlState.ts
+++ b/examples/basic/urlState.ts
@@ -165,13 +165,16 @@ export async function applyHashState(
   // Camera
   const hasLon = isFiniteNumber(state.lon);
   const hasLat = isFiniteNumber(state.lat);
-  if (hasLon && hasLat) {
-    map.jumpTo({
-      center: [state.lon as number, state.lat as number],
-      zoom: isFiniteNumber(state.zoom) ? state.zoom : map.getZoom(),
-      pitch: isFiniteNumber(state.pitch) ? state.pitch : map.getPitch(),
-      bearing: isFiniteNumber(state.bearing) ? state.bearing : map.getBearing(),
-    });
+  const camera = hasLon && hasLat
+    ? {
+        center: [state.lon as number, state.lat as number] as [number, number],
+        zoom: isFiniteNumber(state.zoom) ? state.zoom : map.getZoom(),
+        pitch: isFiniteNumber(state.pitch) ? state.pitch : map.getPitch(),
+        bearing: isFiniteNumber(state.bearing) ? state.bearing : map.getBearing(),
+      }
+    : null;
+  if (camera) {
+    map.jumpTo(camera);
   }
 
   // Data source
@@ -188,7 +191,20 @@ export async function applyHashState(
     });
 
     try {
-      const results: UnifiedSearchItem[] = await control.searchByExtent();
+      // Use a wide bbox around the restored center so state-level dataset ids
+      // (e.g. "VT_Statewide_1_A23") are reliably included even when the user
+      // zoomed in tightly before sharing. searchByExtent at zoom 13 returns
+      // only fine-grained cells and would miss state-wide ids.
+      const lon = hasLon ? (state.lon as number) : map.getCenter().lng;
+      const lat = hasLat ? (state.lat as number) : map.getCenter().lat;
+      const halfDeg = 1.5; // ~165 km half-width — covers most state-level extents
+      const searchBbox: [number, number, number, number] = [
+        lon - halfDeg,
+        lat - halfDeg,
+        lon + halfDeg,
+        lat + halfDeg,
+      ];
+      const results: UnifiedSearchItem[] = await control.searchByBbox(searchBbox);
       const match = results.find((item) => item.id === state.id);
       if (!match) {
         console.warn(
@@ -199,6 +215,12 @@ export async function applyHashState(
       }
     } catch (err) {
       console.warn('[share-url] Search/load failed while restoring state:', err);
+    }
+
+    // searchByBbox triggers autoZoomToResults, which fits the camera to all
+    // footprints. Re-apply the camera from the hash so the shared view wins.
+    if (camera) {
+      map.jumpTo(camera);
     }
   }
 

--- a/src/lib/styles/usgs-lidar-control.css
+++ b/src/lib/styles/usgs-lidar-control.css
@@ -266,6 +266,10 @@
   border-radius: 6px;
 }
 
+.usgs-lidar-results-list:empty {
+  display: none;
+}
+
 .usgs-lidar-result-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #33.

## Summary
- Adds a **Share URL** button at the bottom of the control panel in the basic demo. Clicking it builds a hash URL from the current map view, data source, loaded dataset id, and visualization parameters, then copies it to the clipboard and reflects it in the address bar.
- On page load, the hash is parsed and applied: camera (lon, lat, zoom, pitch, bearing), data source, viz params (point size, opacity, color scheme, colormap, z offset), and — if an `id` is present — a search is run and the matching dataset is auto-loaded.
- Hides the empty `.usgs-lidar-results-list` container so its rounded border no longer renders as a faint double line in the panel when no results are loaded.

The hash format follows the example in the issue:

\`\`\`
#lon=-72.43&lat=44.75&zoom=8.75&pitch=0&bearing=0&source=ept&id=VT_Statewide_1_A23&ptSize=2&opacity=1&color=elevation&cmap=viridis&zoff=320
\`\`\`

Implementation is **demo-only** — the library API is unchanged. The new logic lives in \`examples/basic/urlState.ts\` and is wired up from \`examples/basic/main.ts\`.

## Test plan
- [x] Open the demo, expand the panel, click Share URL: URL bar updates with hash; clipboard contains the same URL.
- [x] Open a URL with camera-only hash: camera is restored after reload.
- [x] Open a URL with \`id=VT_Statewide_1_A23\`: search runs, dataset auto-loads, viz params applied.
- [x] Open a URL with a nonexistent id: warning logged, camera still restored, no crash.
- [x] Open a URL with garbage hash values: no crash, defaults used.