### PR TITLE
Disambiguate Clear labels and disable Search Map Extent while a box is drawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-usgs-lidar",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-usgs-lidar",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "maplibre-gl-layer-control": ">=0.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-usgs-lidar",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A MapLibre GL JS plugin for searching and visualizing USGS 3DEP LiDAR COPC data from Planetary Computer",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -247,6 +247,7 @@ export class PanelBuilder {
 
     const extentBtn = document.createElement('button');
     extentBtn.className = 'usgs-lidar-btn usgs-lidar-btn-primary';
+    extentBtn.id = 'usgs-lidar-extent-btn';
     extentBtn.textContent = 'Search Map Extent';
     extentBtn.addEventListener('click', () => this._callbacks.onSearchByExtent());
     buttonsRow.appendChild(extentBtn);
@@ -287,7 +288,7 @@ export class PanelBuilder {
 
     const clearDrawnBtn = document.createElement('button');
     clearDrawnBtn.className = 'usgs-lidar-btn usgs-lidar-btn-danger';
-    clearDrawnBtn.textContent = 'Clear';
+    clearDrawnBtn.textContent = 'Clear Drawn Area';
     clearDrawnBtn.addEventListener('click', () => this._callbacks.onClearDrawn());
     drawnActions.appendChild(clearDrawnBtn);
 
@@ -344,6 +345,18 @@ export class PanelBuilder {
       }
     }
 
+    // Disable "Search Map Extent" while a drawn bounding box is active, so the
+    // two search scopes (map extent vs drawn area) can't be submitted at once.
+    // It re-enables automatically once the drawn area is cleared.
+    const extentBtn = document.getElementById('usgs-lidar-extent-btn') as HTMLButtonElement | null;
+    if (extentBtn) {
+      const hasDrawnBbox = Boolean(this._state.drawnBbox);
+      extentBtn.disabled = hasDrawnBbox;
+      extentBtn.title = hasDrawnBbox
+        ? 'Clear the drawn area to search by map extent'
+        : '';
+    }
+
     // Update loading indicator
     const loading = document.getElementById('usgs-lidar-search-loading');
     if (loading) {
@@ -395,7 +408,7 @@ export class PanelBuilder {
 
     const clearResultsBtn = document.createElement('button');
     clearResultsBtn.className = 'usgs-lidar-btn usgs-lidar-btn-secondary';
-    clearResultsBtn.textContent = 'Clear';
+    clearResultsBtn.textContent = 'Clear Selection';
     clearResultsBtn.addEventListener('click', () => this._callbacks.onClearResults());
     actionsRow.appendChild(clearResultsBtn);
 
@@ -560,7 +573,7 @@ export class PanelBuilder {
     // Clear all button
     const clearBtn = document.createElement('button');
     clearBtn.className = 'usgs-lidar-btn usgs-lidar-btn-secondary usgs-lidar-btn-full';
-    clearBtn.textContent = 'Clear All';
+    clearBtn.textContent = 'Remove All Loaded Layers';
     clearBtn.addEventListener('click', () => this._callbacks.onClearLoaded());
     content.appendChild(clearBtn);
 

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -249,6 +249,12 @@ export class PanelBuilder {
     extentBtn.className = 'usgs-lidar-btn usgs-lidar-btn-primary';
     extentBtn.id = 'usgs-lidar-extent-btn';
     extentBtn.textContent = 'Search Map Extent';
+    // Seed the drawn-bbox lock on first paint too (the panel can be built with a
+    // bbox already in state); _updateSearchSection keeps it in sync afterwards.
+    extentBtn.disabled = Boolean(this._state.drawnBbox);
+    extentBtn.title = this._state.drawnBbox
+      ? 'Clear the drawn area to search by map extent'
+      : '';
     extentBtn.addEventListener('click', () => this._callbacks.onSearchByExtent());
     buttonsRow.appendChild(extentBtn);
 
@@ -267,18 +273,24 @@ export class PanelBuilder {
 
     content.appendChild(buttonsRow);
 
-    // Drawn bbox info
+    // Drawn bbox info (seeded from state so a preexisting bbox shows on first
+    // paint; _updateSearchSection keeps it in sync afterwards).
     const bboxInfo = document.createElement('div');
     bboxInfo.className = 'usgs-lidar-bbox-info';
     bboxInfo.id = 'usgs-lidar-bbox-info';
-    bboxInfo.style.display = 'none';
+    if (this._state.drawnBbox) {
+      bboxInfo.textContent = `Drawn area: ${formatBbox(this._state.drawnBbox)}`;
+      bboxInfo.style.display = 'block';
+    } else {
+      bboxInfo.style.display = 'none';
+    }
     content.appendChild(bboxInfo);
 
     // Drawn bbox actions
     const drawnActions = document.createElement('div');
     drawnActions.className = 'usgs-lidar-button-row';
     drawnActions.id = 'usgs-lidar-drawn-actions';
-    drawnActions.style.display = 'none';
+    drawnActions.style.display = this._state.drawnBbox ? 'flex' : 'none';
 
     const searchDrawnBtn = document.createElement('button');
     searchDrawnBtn.className = 'usgs-lidar-btn usgs-lidar-btn-primary';

--- a/tests/panel-builder.test.ts
+++ b/tests/panel-builder.test.ts
@@ -79,4 +79,18 @@ describe('PanelBuilder labels and Search Map Extent state', () => {
     expect(extentBtn.disabled).toBe(false);
     expect(extentBtn.title).toBe('');
   });
+
+  it('starts Search Map Extent disabled when built with a preexisting drawn box', () => {
+    // First paint must honor the lock too, not just the updateState refresh path.
+    const panel = new PanelBuilder(noopCallbacks, baseState({ drawnBbox: [-117.71, 37.37, -113.13, 46.61] }));
+    const search = (panel as unknown as { _buildSearchSection(): HTMLElement })._buildSearchSection();
+    document.body.appendChild(search);
+
+    const extentBtn = document.getElementById('usgs-lidar-extent-btn') as HTMLButtonElement;
+    expect(extentBtn.disabled).toBe(true);
+    expect(extentBtn.title).toBe('Clear the drawn area to search by map extent');
+    // The drawn-area info and actions are visible on first paint as well.
+    expect(document.getElementById('usgs-lidar-bbox-info')?.style.display).toBe('block');
+    expect(document.getElementById('usgs-lidar-drawn-actions')?.style.display).toBe('flex');
+  });
 });

--- a/tests/panel-builder.test.ts
+++ b/tests/panel-builder.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PanelBuilder, type PanelCallbacks } from '../src/lib/gui/PanelBuilder';
+import type { UsgsLidarState } from '../src/lib/core/types';
+
+// Every callback is a no-op for these DOM tests; a Proxy returns a fresh
+// function for any property so we don't have to enumerate PanelCallbacks.
+const noopCallbacks = new Proxy({}, { get: () => () => {} }) as unknown as PanelCallbacks;
+
+const baseState = (overrides: Partial<UsgsLidarState> = {}): UsgsLidarState => ({
+  collapsed: false,
+  panelWidth: 380,
+  maxHeight: 500,
+  dataSource: 'ept',
+  searchMode: 'none',
+  isDrawing: false,
+  drawnBbox: null,
+  searchResults: [],
+  selectedItems: new Set(),
+  isSearching: false,
+  searchError: null,
+  totalMatched: null,
+  loadedItems: new Map(),
+  lidarState: null,
+  ...overrides,
+});
+
+describe('PanelBuilder labels and Search Map Extent state', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('uses distinct, scope-specific labels for the three reset actions', () => {
+    const panel = new PanelBuilder(noopCallbacks, baseState());
+    // Build the relevant sections in isolation (the visualization section uses
+    // a <canvas>, which jsdom does not implement) and mount them so the
+    // document-scoped lookups below resolve.
+    const search = (panel as unknown as { _buildSearchSection(): HTMLElement })._buildSearchSection();
+    const results = (panel as unknown as { _buildResultsSection(): HTMLElement })._buildResultsSection();
+    const loaded = (panel as unknown as { _buildLoadedSection(): HTMLElement })._buildLoadedSection();
+    document.body.append(search, results, loaded);
+
+    // Drawn-area reset (danger button in the drawn-area actions row).
+    expect(search.querySelector('.usgs-lidar-btn-danger')?.textContent).toBe('Clear Drawn Area');
+    // Results selection reset.
+    const resultsClear = results.querySelector('#usgs-lidar-results-actions .usgs-lidar-btn-secondary');
+    expect(resultsClear?.textContent).toBe('Clear Selection');
+    // Loaded-layers global reset.
+    expect(loaded.querySelector('.usgs-lidar-btn-full')?.textContent).toBe('Remove All Loaded Layers');
+    // The three labels must all differ.
+    const labels = ['Clear Drawn Area', 'Clear Selection', 'Remove All Loaded Layers'];
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it('disables Search Map Extent only while a drawn bounding box is active', () => {
+    const panel = new PanelBuilder(noopCallbacks, baseState());
+    const internals = panel as unknown as {
+      _buildSearchSection(): HTMLElement;
+      _searchSection: HTMLElement;
+    };
+    const search = internals._buildSearchSection();
+    // build() normally assigns this; set it so updateState() runs the search
+    // section update path.
+    internals._searchSection = search;
+    document.body.appendChild(search);
+
+    const extentBtn = document.getElementById('usgs-lidar-extent-btn') as HTMLButtonElement;
+    expect(extentBtn).not.toBeNull();
+    expect(extentBtn.textContent).toBe('Search Map Extent');
+    // No drawn area initially: enabled.
+    expect(extentBtn.disabled).toBe(false);
+
+    // Drawing a box disables it (so the two search scopes can't both fire).
+    panel.updateState(baseState({ drawnBbox: [-117.71, 37.37, -113.13, 46.61] }));
+    expect(extentBtn.disabled).toBe(true);
+    expect(extentBtn.title).toBe('Clear the drawn area to search by map extent');
+
+    // Clearing the box re-enables it automatically.
+    panel.updateState(baseState({ drawnBbox: null }));
+    expect(extentBtn.disabled).toBe(false);
+    expect(extentBtn.title).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the UX report in opengeos/GeoLibre#999 against the USGS LiDAR control panel.

Two issues:

1. **Ambiguous "Clear" labels.** The panel used the bare label `Clear` for two different reset actions (the drawn-area bounds and the results selection) and `Clear All` for removing loaded layers. Stacked vertically, it was unclear which scope a click discards.
2. **Conflicting search controls.** With a custom bounding box drawn, `Search Map Extent` stayed enabled, so the map-extent and drawn-area search scopes could both be submitted.

## Changes (`src/lib/gui/PanelBuilder.ts`)

- Scope-specific reset labels: `Clear` (drawn area) → **Clear Drawn Area**, `Clear` (results) → **Clear Selection**, `Clear All` → **Remove All Loaded Layers**.
- `Search Map Extent` is now disabled while a drawn bounding box is active (with a tooltip: "Clear the drawn area to search by map extent"); it re-enables automatically when the area is cleared. The existing `.usgs-lidar-btn:disabled` style grays it out.
- Added `tests/panel-builder.test.ts` (jsdom) covering the three distinct labels and the extent enable → disable → enable toggle.

## Verification

`npm run build`, `npm test` (11 passing), and `npm run lint` are green. Also verified in the real GeoLibre app via a local dist swap, in both light and dark themes: drawing a rectangle disables `Search Map Extent` and shows the `Clear Drawn Area` action; clearing it re-enables the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search controls to clearly distinguish searching the map extent from searching a drawn area.
  * The map-extent search action now disables when a drawn area is active, with guidance to clear it first.

* **Bug Fixes**
  * Updated button labels to be more specific and easier to understand: “Clear Drawn Area,” “Clear Selection,” and “Remove All Loaded Layers.”

* **Chores**
  * Bumped the app version to 0.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->